### PR TITLE
Add missing step for activiating the venv

### DIFF
--- a/AI-Agents-with-MongoDB/01-Building-AI-Agents-with-MongoDB/README.md
+++ b/AI-Agents-with-MongoDB/01-Building-AI-Agents-with-MongoDB/README.md
@@ -44,7 +44,8 @@ Each lesson builds upon the previous one, providing a gradual learning experienc
 3. Create and initialize a `uv` environment:
 
    ```bash
-   uv init
+   mkdir ai-agents && cd ai-agents && \
+   uv init && uv venv && source .venv/bin/activate
    ```
 
 4. Install the required dependencies:


### PR DESCRIPTION
Adds steps to create and change into a new directory, activate a uv project, create a virtual env, and activate it.

Noticed this was missing from the instructions.