### PR TITLE
Update voyageai package version in README

### DIFF
--- a/AI-Agents-with-MongoDB/01-Building-AI-Agents-with-MongoDB/README.md
+++ b/AI-Agents-with-MongoDB/01-Building-AI-Agents-with-MongoDB/README.md
@@ -99,7 +99,7 @@ source .venv/bin/activate
 Install all required packages:
 
 ```bash
-uv add langchain==0.3.24 langchain-openai==0.3.14 langgraph==0.3.31 langgraph-checkpoint-mongodb==0.1.3 pymongo==4.11.3 voyageai==0.3.2 datasets
+uv add langchain==0.3.24 langchain-openai==0.3.14 langgraph==0.3.31 langgraph-checkpoint-mongodb==0.1.3 pymongo==4.11.3 voyageai==0.3.7 datasets
 ```
 
 **Verify installation:**


### PR DESCRIPTION
The new version of voyageapi correctly identifies the base_url. The old version always hits api.voyageai.com.